### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ yarn cljs:build
 
 yarn run ios # or android
 ```
+- on Apple M1 dependencies can be installed by running `arch -x86_64 pod install` inside `/ios` folder.
 
 ## Workflow
 


### PR DESCRIPTION
- adding extra instructions for Apple M1 regarding deps.

- if deps are missing, XCode build fails...